### PR TITLE
Allow user to set the q basis after an optic is added to the opt.

### DIFF
--- a/@Optickle/setFrontBasisForMirror.m
+++ b/@Optickle/setFrontBasisForMirror.m
@@ -1,0 +1,18 @@
+function opt = setFrontBasisForMirror(opt,sn,dWaist)
+  % opt = setFrontBasisForOptic(opt,'name',dWaist)
+  %   Set the distance from the beam waist to the front
+  %   input of this mirror.  For non-flat mirrors,
+  %   the Rayleigh Range of the input beam is given by
+  %   z0 = sqrt(dWaist * (1/Chr - dWaist))
+  %   The argument of the sqrt must be positive.
+  %
+  %   see <a href="matlab:help Mirror/setFrontBasis">Mirror.setFrontBasis</a> for more info
+
+  if ischar(sn)
+      sn = getSerialNum(opt,sn);
+  end
+  
+  obj = opt.optic{sn};
+  
+  opt.optic{sn} = setFrontBasis(obj, dWaist);
+end


### PR DESCRIPTION
In response to Keiko needing to set the q basis of an optic after creating the opt:

I copy paste a part using setFrontBasis giving me an error. I now think I used in a wrong way (the last sentence, opt can not be changed), but I am not sure how to change opt.optic in a different way.
%  opt = optFP;
%  sn1 = getSerialNum(opt, 'EX');
%  obj1 = opt.optic{sn1};
%   z = 5;
%  opt.optic{sn1} = setFrontBasis(obj1, z);
