### PR TITLE
Fixes setPosOffset for BeamSplitter.

### DIFF
--- a/@BeamSplitter/BeamSplitter.m
+++ b/@BeamSplitter/BeamSplitter.m
@@ -113,6 +113,19 @@ classdef BeamSplitter < Optic
       
       [vThr, vLhr, vRar, vLmd] = obj.mir.getVecProperties(lambda, pol);
     end
+    %%%% Protected Properties %%%%
+    function obj = setPosOffset(obj, pos)
+      % set the position offset for an optic
+      %
+      % obj = setPosOffset(obj, pos)
+      
+      if length(pos) ~= obj.Ndrive
+        error('%s: drive positions not equal to number of drives (%d ~= %d)', ...
+          obj.name, length(pos), obj.Ndrive);
+      end
+      %obj.pos = pos(:); %fix this for BS mir object
+      obj.mir = setPosOffset(obj.mir,pos);
+    end
     function obj = setMechTF(obj, mechTF, nDOF)
         % sets the mechTF property for the BS and internal mirror object
         


### PR DESCRIPTION
## Issue raised by Sean Leavy:

I've been trying to set a position offset on some beam splitters in my Optickle model. The standard setPosOffset(...) method, i.e.

opt.setPosOffset('BS', 100e-9);

doesn't seem to do anything, however. I can see that the method BeamSplitter.getFieldMatrix(...) is calling Mirror.getFieldMatrix(...) via the BeamSplitter's internal reference to the mirror object 'mir', but 'mir' doesn't get updated with the position offset when it is defined on the BeamSplitter. This leads to a field matrix which assumes the position offset of the beam splitter is 0 regardless of its actual position offset.

A workaround is simply to set the position offset in this way:

opt.getOptic('BS').mir.setPosOffset(100e-9);

But I guess this is a bug that users should be aware of. I don't know enough about the object structure of Optickle2 to submit a patch to the git repo, but I attach a minimal example. It shows the transmitted light from a simple Fabry-Perot. On resonance the transmitted light should be 34 mW. In two iterations, I set a position offset of the ETM first with setPosOffset and then with the workaround. The example shows that in the first case the transmitted light is still 34 mW, which means it's not setting the position offset properly.
